### PR TITLE
Remoção de opção 'out-of-order'

### DIFF
--- a/autuacao.yml
+++ b/autuacao.yml
@@ -18,6 +18,3 @@ spring:
       
 hystrix.command.default.execution.isolation:
   thread.timeoutInMilliseconds: 20000
-
-flyway:
-  out-of-order: true


### PR DESCRIPTION
A inclusão da opção foi necessária para aplicação de alguns scripts que foram inseridos com ordem de execução anterior à última registrada pelo flyway.